### PR TITLE
resources/htmlTemplate: Logo moved from spdx.linuxfound.info to spdx.org

### DIFF
--- a/resources/htmlTemplate/ExceptionHTMLTemplate.html
+++ b/resources/htmlTemplate/ExceptionHTMLTemplate.html
@@ -124,7 +124,7 @@
   <div id="header">
     <div id="header-inner">
       <a href="/" title="Home" rel="home" id="logo">
-        <img src="https://spdx.linuxfound.info/sites/cpstandard/files/logo_spdx_250.png" alt="Home" />
+        <img src="https://spdx.org/sites/cpstandard/files/logo_spdx_250.png" alt="Home" />
       </a>
       
       <div id="name-and-slogan">

--- a/resources/htmlTemplate/ExceptionsTocHTMLTemplate.html
+++ b/resources/htmlTemplate/ExceptionsTocHTMLTemplate.html
@@ -112,7 +112,7 @@
   <div id="header">
     <div id="header-inner">
       <a href="/" title="Home" rel="home" id="logo">
-        <img src="https://spdx.linuxfound.info/sites/cpstandard/files/logo_spdx_250.png" alt="Home" />
+        <img src="https://spdx.org/sites/cpstandard/files/logo_spdx_250.png" alt="Home" />
       </a>
       
       <div id="name-and-slogan">

--- a/resources/htmlTemplate/LicenseHTMLTemplate.html
+++ b/resources/htmlTemplate/LicenseHTMLTemplate.html
@@ -117,7 +117,7 @@
   <div id="header">
     <div id="header-inner">
       <a href="/" title="Home" rel="home" id="logo">
-        <img src="https://spdx.linuxfound.info/sites/cpstandard/files/logo_spdx_250.png" alt="Home" />
+        <img src="https://spdx.org/sites/cpstandard/files/logo_spdx_250.png" alt="Home" />
       </a>
       
       <div id="name-and-slogan">

--- a/resources/htmlTemplate/TocHTMLTemplate.html
+++ b/resources/htmlTemplate/TocHTMLTemplate.html
@@ -115,7 +115,7 @@
   <div id="header">
     <div id="header-inner">
       <a href="/" title="Home" rel="home" id="logo">
-        <img src="https://spdx.linuxfound.info/sites/cpstandard/files/logo_spdx_250.png" alt="Home" />
+        <img src="https://spdx.org/sites/cpstandard/files/logo_spdx_250.png" alt="Home" />
       </a>
       
       <div id="name-and-slogan">


### PR DESCRIPTION
Adjust to the upstream redirect:

```console
$ curl -I https://spdx.linuxfound.info/sites/cpstandard/files/logo_spdx_250.png
HTTP/1.1 301 Moved Permanently
…
Location: https://spdx.org/sites/cpstandard/files/logo_spdx_250.png
…
```

Generated with:

```console
$ sed -i 's/spdx.linuxfound.info/spdx.org/g' $(git grep -l linuxfound.info)
```