### PR TITLE
Add metadata for deprecated licenses.  

### DIFF
--- a/src/org/spdx/licenselistpublisher/LicenseRDFAGenerator.java
+++ b/src/org/spdx/licenselistpublisher/LicenseRDFAGenerator.java
@@ -510,6 +510,7 @@ public class LicenseRDFAGenerator {
 		while (depIter.hasNext()) {
 			System.out.print(".");
 			DeprecatedLicenseInfo deprecatedLicense = depIter.next();
+			addExternalMetaData(deprecatedLicense.getLicense());
 			for (ILicenseFormatWriter writer : writers) {
 				writer.writeLicense(deprecatedLicense.getLicense(), true, deprecatedLicense.getDeprecatedVersion());
 			}


### PR DESCRIPTION
Fixes issue where the isFsfFree flag is not being set for deprecated licenses.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>