### PR TITLE
Add link to spdx.org/ids

### DIFF
--- a/resources/htmlTemplate/TocHTMLTemplate.html
+++ b/resources/htmlTemplate/TocHTMLTemplate.html
@@ -148,6 +148,7 @@
             <li style="margin:5px 0 5px 10px;"><a href="https://github.com/spdx/license-list-XML"><strong>Master Files</strong></a>:  The HTML pages you see here are generated from the master files for the SPDX License List. </li>
             <li style="margin:5px 0 5px 10px;"><a href="https://github.com/spdx/license-list-data"><strong>Data Files</strong></a>:  Machine readable files describing all of the licenses and license exceptions.</li>
             <li style="margin:0px 0 5px 10px;"><a href="http://spdx.org/spdx-license-list/license-list-overview"><strong>Overview</strong></a>: General information about the SPDX License List, including principles for inclusion of a license and an explanation of the fields contained on the list.</li>
+            <li style="margin:0px 0 5px 10px;"><a href="http://spdx.org/ids"><strong>IDs</strong></a>: Learn more about using short-form license identifiers in your source code.</li>
             <li style="margin:5px 0 5px 10px;"><a href="http://spdx.org/spdx-license-list/matching-guidelines"><strong>Matching Guidelines</strong></a>:  Guidelines for what constitutes a license match to the SPDX License List. The license text on the HTML pages here will display omitable text in blue and replaceable text in red (see Guideline #2 for more information).</li>
             <li style="margin:5px 0 5px 10px;"><a href="https://github.com/spdx/license-list-XML/blob/master/CONTRIBUTING.md"><strong>Request New License</strong></a>: Instructions for proposing a license or exception be added to the SPDX License List.</li>
 


### PR DESCRIPTION
In the template for the main license list TOC, add a link to the spdx.org/ids page since the regular spdx.org website menu bar doesn't appear on the license list pages.

Fixes #46 

Signed-off-by: Steve Winslow <swinslow@gmail.com>