### PR TITLE
Allow for a single file to be specified in the LicenseRDFaGenerator command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ The command line interface of the licenseListPublisher can be used like this:
 Where the following functions and parameters are supported:
 
 ```
-LicenseRDFAGenerator licencenseXmlDir outputDirectory [version] [releasedate] [testfiles] [ignoredwarnings]
-   licencenseXmlDir - a directory of license XML files
+LicenseRDFAGenerator licencenseXmlFileOrDir outputDirectory [version] [releasedate] [testfiles] [ignoredwarnings]
+   licencenseXmlFileOrDir - a license XML file or a directory of license XML files
    outputDirectory - Directory to store the output from the license generator
    [version] - Version of the SPDX license list
    [releasedate] - Release date of the SPDX license list
@@ -47,6 +47,9 @@ TestLicenseXML licenseXmlFile textFile
    licenseXmlFile XML - file to test
    textFile - Text file which should match the the license text for the licenseXmlFile
 ```
+
+## WARNING
+Running the LicenseRDFaGenerator for a single file will overwrite any index.html, licenses.json etc. with the single file results.
 
 # License
 See the [NOTICE](NOTICE) file for licensing information

--- a/src/org/spdx/licenselistpublisher/LicenseXmlTester.java
+++ b/src/org/spdx/licenselistpublisher/LicenseXmlTester.java
@@ -1,6 +1,21 @@
 /**
+ * SpdxLicenseIdentifier: Apache-2.0
  * 
- */
+ * Copyright (c) 2019 Source Auditor Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+*/
 package org.spdx.licenselistpublisher;
 
 import java.io.File;

--- a/src/org/spdx/licensexml/XmlLicenseProviderSingleFile.java
+++ b/src/org/spdx/licensexml/XmlLicenseProviderSingleFile.java
@@ -1,0 +1,89 @@
+/**
+ * SpdxLicenseIdentifier: Apache-2.0
+ * 
+ * Copyright (c) 2019 Source Auditor Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+*/
+package org.spdx.licensexml;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.spdx.rdfparser.InvalidSPDXAnalysisException;
+import org.spdx.rdfparser.license.ISpdxListedLicenseProvider;
+import org.spdx.rdfparser.license.LicenseRestrictionException;
+import org.spdx.rdfparser.license.ListedLicenseException;
+import org.spdx.rdfparser.license.SpdxListedLicense;
+import org.spdx.rdfparser.license.SpdxListedLicenseException;
+import org.spdx.spdxspreadsheet.SpreadsheetException;
+
+/**
+ * 
+ * @author Gary O'Neall
+ *
+ */
+public class XmlLicenseProviderSingleFile implements ISpdxListedLicenseProvider {
+	
+	Logger logger = LoggerFactory.getLogger(XmlLicenseProviderSingleFile.class.getName());
+	private List<String> warnings = new ArrayList<String>();
+	LicenseXmlDocument licDoc = null;
+	
+	public XmlLicenseProviderSingleFile(File licenseXmlFile) throws LicenseXmlException {
+		licDoc = new LicenseXmlDocument(licenseXmlFile);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.spdx.rdfparser.license.ISpdxListedLicenseProvider#getLicenseIterator()
+	 */
+	@Override
+	public Iterator<SpdxListedLicense> getLicenseIterator() throws SpdxListedLicenseException {
+		try {
+			return licDoc.getListedLicenses().iterator();
+		} catch (InvalidSPDXAnalysisException e) {
+			logger.error("SPDX Analysis exception getting license iterator",e);
+			throw new SpdxListedLicenseException("SPDX Analysis exception getting license iterator",e);
+		} catch (LicenseXmlException e) {
+			logger.error("License XML exception getting license iterator",e);
+			throw new SpdxListedLicenseException("Invalid License XML Document",e);
+		}
+	}
+
+	/* (non-Javadoc)
+	 * @see org.spdx.rdfparser.license.ISpdxListedLicenseProvider#getExceptionIterator()
+	 */
+	@Override
+	public Iterator<ListedLicenseException> getExceptionIterator()
+			throws LicenseRestrictionException, SpreadsheetException {
+		try {
+			return licDoc.getLicenseExceptions().iterator();
+		} catch (LicenseXmlException e) {
+			logger.error("License XML exception getting license iterator",e);
+			throw new RuntimeException(new SpdxListedLicenseException("Invalid License XML Document",e));
+		}
+	}
+
+	/* (non-Javadoc)
+	 * @see org.spdx.rdfparser.license.ISpdxListedLicenseProvider#getWarnings()
+	 */
+	@Override
+	public List<String> getWarnings() {
+		return warnings;
+	}
+
+}


### PR DESCRIPTION
Resolves issue #51 

WARNING: Running this with a single file will generate new index.html, licenses.json etc with only the single license or exception being represented in the file - this may overwrite existing licenses.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>