### PR TITLE
Remove JSoup dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,11 +73,6 @@
 		    <version>1.6</version>
 		</dependency>
 		<dependency>
-		    <groupId>org.jsoup</groupId>
-		    <artifactId>jsoup</artifactId>
-		    <version>1.13.1</version>
-		</dependency>
-		<dependency>
 			<groupId>org.spdx</groupId>
 			<artifactId>java-spdx-library</artifactId>
 			<version>1.0.6</version>


### PR DESCRIPTION
JSoup is already included as a dependency in the Spdx-Java-Library which is included as a dependency - there is no need to include it in this project.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>