### PR TITLE
Improve contrast of the generated website

### DIFF
--- a/resources/htmlTemplate/ExceptionHTMLTemplate.html
+++ b/resources/htmlTemplate/ExceptionHTMLTemplate.html
@@ -41,7 +41,7 @@
       }
 
       #page h2, h3, h4, h5 {
-        color: #4597cb;
+        color: #00416b;
       }
        
       #page h1 {
@@ -53,7 +53,7 @@
       }
 
       a, a:visited, a:hover {
-        color: #4597cb;
+        color: #00416b;
       }
 
       #footer-copyright {

--- a/resources/htmlTemplate/ExceptionsTocHTMLTemplate.html
+++ b/resources/htmlTemplate/ExceptionsTocHTMLTemplate.html
@@ -41,7 +41,7 @@
       }
 
       #page h2, h3, h4, h5 {
-        color: #4597cb;
+        color: #00416b;
       }
 
       #page p {
@@ -49,7 +49,7 @@
       }
 
       a, a:visited, a:hover {
-        color: #4597cb;
+        color: #00416b;
       }
 
       #footer-copyright {

--- a/resources/htmlTemplate/LicenseHTMLTemplate.html
+++ b/resources/htmlTemplate/LicenseHTMLTemplate.html
@@ -41,7 +41,7 @@
       }
 
       .page h2, h3, h4, h5 {
-        color: #4597cb;
+        color: #00416b;
       }
 
       .page h1 {
@@ -53,7 +53,7 @@
       }
 
       a, a:visited, a:hover {
-        color: #4597cb;
+        color: #00416b;
       }
 
       #footer-copyright {

--- a/resources/htmlTemplate/TocHTMLTemplate.html
+++ b/resources/htmlTemplate/TocHTMLTemplate.html
@@ -41,7 +41,7 @@
       }
 
       #page h2, h3, h4, h5 {
-        color: #4597cb;
+        color: #00416b;
       }
 
       #page p {
@@ -49,7 +49,7 @@
       }
 
       a, a:visited, a:hover {
-        color: #4597cb;
+        color: #00416b;
       }
 
       #footer-copyright {


### PR DESCRIPTION
This commit changes the colour of the text in the generated website from light blue to the dark blue of the SPDX logo, in order to meet Level AAA of the Web Content Accessibility Guidelines (WCAG) for contrast.

See also <https://github.com/spdx/spdx-spec/pull/574>, which made this change (and other contrast improvements) to the SPDX specification website.