### PR TITLE
Update SPDX Library version to 1.0.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.spdx</groupId>
 	<artifactId>licenseListPublisher</artifactId>
-	<version>2.2.5-SNAPSHOT</version>
+	<version>2.2.5</version>
 	<name>License List Publisher</name>
 	<description>Tool that generates license data found in the license-list-data repository from the license-list-XML source</description>
 	<licenses>
@@ -70,7 +70,7 @@
 		<dependency>
 			<groupId>org.spdx</groupId>
 			<artifactId>java-spdx-library</artifactId>
-			<version>1.0.9</version>
+			<version>1.0.10</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.spullara.mustache.java</groupId>
@@ -90,7 +90,7 @@
 		<dependency>
 			<groupId>org.spdx</groupId>
 			<artifactId>spdx-rdf-store</artifactId>
-			<version>1.0.3</version>
+			<version>1.0.4</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>
@@ -184,7 +184,7 @@
 			<plugin>
 				<groupId>org.spdx</groupId>
 					<artifactId>spdx-maven-plugin</artifactId>
-					<version>0.5.4</version>
+					<version>0.5.5</version>
 					<executions>
 						<execution>
 							<id>build-spdx</id>


### PR DESCRIPTION
Updates log4j to version 2.17.0 resolving possible vulnerabilities
CVE-2021-44228 and CVE-2021-45046

Note that the current usage of the licenseListPublisher makes it unlikely this vulnerability would be exploited.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>