### PR TITLE
Clarify that the license identifier is deprecated

### DIFF
--- a/resources/htmlTemplate/LicenseHTMLTemplate.html
+++ b/resources/htmlTemplate/LicenseHTMLTemplate.html
@@ -133,7 +133,7 @@
       <h1 property="dc:title">{{title}}</h1>
       {{#deprecated}}
       <h1 style="color:red">Deprecated</h1>
-      <div style="color:red">This license has been deprecated since license list version {{deprecatedVersion}}.</div>
+      <div style="color:red">This license identifier has been deprecated since license list version {{deprecatedVersion}}.</div>
       <div style="display:none;"><code property="spdx:deprecated">true</code></div>
       {{/deprecated}}
       {{^deprecated}}


### PR DESCRIPTION
Clarify that the SPDX license identifier, and not the license itself,
is deprecated.

Signed-off-by: John Neffenger <john@status6.com>
