### PR TITLE
Update README and fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,23 @@
 Contributing
 ============
+
 Thank you for your interest in `licenseListPublisher`. The project is open-source software, and bug reports, suggestions, and most especially patches are welcome.
 
 Issues
 ------
+
 `licenseListPublisher` has a [project page on GitHub](https://github.com/spdx/licenseListPublisher/) where you can [create an issue](https://github.com/spdx/licenseListPublisher/issues/new) to report a bug, make a suggestion, or propose a substantial change or improvement that you might like to make. You may also wish to contact the SPDX working group technical team through its mailing list, [spdx-tech@lists.spdx.org](mailto:spdx-tech@lists.spdx.org).
 
 If you would like to work on a fix for any issue, please assign the issue to yourself prior to creating a patch.
 
 Patches
 -------
+
 The source code for `LicenseListPublisher` is hosted on [github.com/spdx/LicenseListPublisher](https://github.com/spdx/LicenseListPublisher). Please review [open pull requests](https://github.com/spdx/licenseListPublisher/pulls) and [active branches](https://github.com/spdx/licenseListPublisher/branches) before committing time to a substantial revision. Work along similar lines may already be in progress.
 
 To submit a patch via GitHub, fork the repository, create a topic branch from `master` for your work, and send a pull request when ready. If you would prefer to send a patch or grant access to pull from your own Git repository, please contact the project's contributors by e-mail.
 
-
 Licensing
 ---------
+
 However you choose to contribute, please confirm in a comment to your pull request or by e-mail that you license your contributions under the terms of [the Apache License, Version 2.0](http://spdx.org/licenses/Apache-2.0).

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Where the following functions are supported:
 - `LicenseRDFAGenerator` - Generates license data
 - `TestLicenseXML` - Tests a license XML file
 
-### LicenseRDFAGenerator parameters
+### LicenseRDFAGenerator
 
 Usage:
 
@@ -46,7 +46,10 @@ LicenseRDFAGenerator licenseXmlFileOrDir outputDirectory [version] [releasedate]
    [ignoredwarnings] - Either a file name or a comma separated list of warnings to be ignored
 ```
 
-### TestLicenseXML parameters
+**WARNING:** Running the LicenseRDFAGenerator for a single file
+will overwrite any index.html, licenses.json etc. with the single file results.
+
+### TestLicenseXML
 
 Usage:
 
@@ -57,16 +60,12 @@ TestLicenseXML licenseXmlFile textFile
    testDirectory - Optional directory of test files in the form {license-id}/(license|header|exception)/(good|bad)/{test-id}.txt
 ```
 
-## WARNING
-
-Running the LicenseRDFaGenerator for a single file will overwrite any index.html, licenses.json etc. with the single file results.
-
 ## License
 
 See the [NOTICE](NOTICE) file for licensing information
-including info from 3rd Party Software
+including info from 3rd Party Software.
 
-See [LICENSE](LICENSE) file for full license text
+See [LICENSE](LICENSE) file for full license text.
 
 ```text
 SPDX-License-Identifier: Apache-2.0
@@ -75,7 +74,7 @@ PackageLicenseDeclared:  Apache-2.0
 
 ## Development
 
-## Build
+### Build
 
 You need [Apache Maven](http://maven.apache.org/) to build the project:
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,42 @@
-[![Build Status](https://travis-ci.org/spdx/LicenseListPublisher.svg?branch=master)](https://travis-ci.org/spdx/LicenseListPublisher)
-
 # LicenseListPublisher
 
 This is the source code repository for the tool that generates license data found in the [license-list-data](https://github.com/spdx/license-list-data) repository.  The source for the the data is located in the [license-list-XML](https://github.com/spdx/license-list-XML) repository.
 
-# Code quality badges
+## Code quality badges
 
-|   [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=licenseListPublisher&metric=bugs)](https://sonarcloud.io/dashboard?id=licenseListPublisher)    | [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=licenseListPublisher&metric=security_rating)](https://sonarcloud.io/dashboard?id=licenseListPublisher) | [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=licenseListPublisher&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=licenseListPublisher) | [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=licenseListPublisher&metric=sqale_index)](https://sonarcloud.io/dashboard?id=licenseListPublisher) |
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=licenseListPublisher&metric=bugs)](https://sonarcloud.io/dashboard?id=licenseListPublisher)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=licenseListPublisher&metric=security_rating)](https://sonarcloud.io/dashboard?id=licenseListPublisher)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=licenseListPublisher&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=licenseListPublisher)
+[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=licenseListPublisher&metric=sqale_index)](https://sonarcloud.io/dashboard?id=licenseListPublisher)
 
 ## Getting Starting
 
-The package is available in [Maven Central](https://search.maven.org/artifact/org.spdx/licenseListPublisher) (organization org.spdx, artifact licenseListPublisher).
+The package is available in
+[Maven Central](https://search.maven.org/artifact/org.spdx/licenseListPublisher)
+(organization: `org.spdx`, artifact: `licenseListPublisher`).
 
 ## Contributing
+
 See the file [CONTRIBUTING.md](CONTRIBUTING.md) for information on making contributions to the LicenseListPublisher.
 
 ## Syntax
+
 The command line interface of the licenseListPublisher can be used like this:
 
-    java -jar licenseListPublisher.jar <function> <parameters> 
-
-Where the following functions and parameters are supported:
-
+```shell
+java -jar licenseListPublisher.jar <function> <parameters> 
 ```
+
+Where the following functions are supported:
+
+- `LicenseRDFAGenerator` - Generates license data
+- `TestLicenseXML` - Tests a license XML file
+
+### LicenseRDFAGenerator parameters
+
+Usage:
+
+```text
 LicenseRDFAGenerator licencenseXmlFileOrDir outputDirectory [version] [releasedate] [testfiles] [ignoredwarnings]
    licencenseXmlFileOrDir - a license XML file or a directory of license XML files
    outputDirectory - Directory to store the output from the license generator
@@ -32,27 +46,39 @@ LicenseRDFAGenerator licencenseXmlFileOrDir outputDirectory [version] [releaseda
    [ignoredwarnings] - Either a file name or a comma separated list of warnings to be ignored
 ```
 
-```
+### TestLicenseXML parameters
+
+Usage:
+
+```text
 TestLicenseXML licenseXmlFile textFile
    licenseXmlFile XML - file to test
    textFile - Text file which should match the the license text for the licenseXmlFile
+   testDirectory - Optional directory of test files in the form {license-id}/(license|header|exception)/(good|bad)/{test-id}.txt
 ```
 
 ## WARNING
+
 Running the LicenseRDFaGenerator for a single file will overwrite any index.html, licenses.json etc. with the single file results.
 
-# License
+## License
+
 See the [NOTICE](NOTICE) file for licensing information
 including info from 3rd Party Software
 
 See [LICENSE](LICENSE) file for full license text
 
-    SPDX-License-Identifier:	Apache-2.0
-    PackageLicenseDeclared:		Apache-2.0
+```text
+SPDX-License-Identifier: Apache-2.0
+PackageLicenseDeclared:  Apache-2.0
+```
 
-# Development
+## Development
 
 ## Build
+
 You need [Apache Maven](http://maven.apache.org/) to build the project:
 
-    mvn clean install
+```shell
+mvn clean install
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LicenseListPublisher
 
-This is the source code repository for the tool that generates license data found in the [license-list-data](https://github.com/spdx/license-list-data) repository.  The source for the the data is located in the [license-list-XML](https://github.com/spdx/license-list-XML) repository.
+This is the source code repository for the tool that generates license data found in the [license-list-data](https://github.com/spdx/license-list-data) repository.  The source for the data is located in the [license-list-XML](https://github.com/spdx/license-list-XML) repository.
 
 ## Code quality badges
 
@@ -46,8 +46,8 @@ LicenseRDFAGenerator licenseXmlFileOrDir outputDirectory [version] [releasedate]
    [ignoredwarnings] - Either a file name or a comma separated list of warnings to be ignored
 ```
 
-**WARNING:** Running the LicenseRDFAGenerator for a single file
-will overwrite any index.html, licenses.json etc. with the single file results.
+***WARNING:** Running the LicenseRDFAGenerator for a single file
+will overwrite any index.html, licenses.json etc. with the single file results.*
 
 ### TestLicenseXML
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Where the following functions are supported:
 Usage:
 
 ```text
-LicenseRDFAGenerator licencenseXmlFileOrDir outputDirectory [version] [releasedate] [testfiles] [ignoredwarnings]
-   licencenseXmlFileOrDir - a license XML file or a directory of license XML files
+LicenseRDFAGenerator licenseXmlFileOrDir outputDirectory [version] [releasedate] [testfiles] [ignoredwarnings]
+   licenseXmlFileOrDir - a license XML file or a directory of license XML files
    outputDirectory - Directory to store the output from the license generator
    [version] - Version of the SPDX license list
    [releasedate] - Release date of the SPDX license list

--- a/src/org/spdx/htmltemplates/package-info.java
+++ b/src/org/spdx/htmltemplates/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Classes that manage the HTML templates used to output HTML formated license information
+ * Classes that manage the HTML templates used to output HTML formatted license information
  *
  * @author Gary O'Neall
  *

--- a/src/org/spdx/licenselistpublisher/LicenseRDFAGenerator.java
+++ b/src/org/spdx/licenselistpublisher/LicenseRDFAGenerator.java
@@ -121,7 +121,7 @@ public class LicenseRDFAGenerator {
 	 *             arg 1 is the directory for the output html files
 	 *             arg 2 is the optional license list version
 	 *             arg 3 is the optional release date
-	 *             arg 4 is the optional directory of original license texts with file names {license-or-excpetion-id}.txt
+	 *             arg 4 is the optional directory of original license texts with file names {license-or-exception-id}.txt
 	 *             arg 5 is the optional file containing a list of warnings to ignore
 	 *             arg 6 is the optional directory of positive and negative tests for the licenses with the pattern {license-id}/(license|header|exception)/(good|bad)/{test-id}.txt
 	 */

--- a/src/org/spdx/licenselistpublisher/LicenseRDFAGenerator.java
+++ b/src/org/spdx/licenselistpublisher/LicenseRDFAGenerator.java
@@ -672,8 +672,8 @@ public class LicenseRDFAGenerator {
 
 	private static void usage() {
 		System.out.println("Usage:");
-		System.out.println("LicenseRDFAGenerator licencenseXmlFileOrDir outputDirectory [version] [releasedate] [testfiles] [ignoredwarnings]");
-		System.out.println("   licencenseXmlFileOrDir - a license XML file or a directory of license XML files");
+		System.out.println("LicenseRDFAGenerator licenseXmlFileOrDir outputDirectory [version] [releasedate] [testfiles] [ignoredwarnings]");
+		System.out.println("   licenseXmlFileOrDir - a license XML file or a directory of license XML files");
 		System.out.println("   outputDirectory - Directory to store the output from the license generator");
 		System.out.println("   [version] - Version of the SPDX license list");
 		System.out.println("   [releasedate] - Release date of the SPDX license list");

--- a/src/org/spdx/licenselistpublisher/MarkdownTable.java
+++ b/src/org/spdx/licenselistpublisher/MarkdownTable.java
@@ -199,7 +199,7 @@ public class MarkdownTable {
 		writer.write("The following licenses have been generated from the license list version ");
 		writer.write(licenseListVersion);
 		writer.write("\n\n");
-		writer.write("## Licenses with Short Idenifiers\n\n");
+		writer.write("## Licenses with Short Identifiers\n\n");
 		String licenseTableHeaderFormat = "| %-"+maxLicenseName+"s | %-"+maxShortIdLength+"s | %-4s | %-9s |\n";
 		writer.write(String.format(licenseTableHeaderFormat, "Full Name of License", "Short Identifier","OSI?", "FSFLibre?" ));
 		writer.write("|-");

--- a/src/org/spdx/licenselistpublisher/licensegenerator/LicenseMarkdownFormatWriter.java
+++ b/src/org/spdx/licenselistpublisher/licensegenerator/LicenseMarkdownFormatWriter.java
@@ -36,7 +36,7 @@ public class LicenseMarkdownFormatWriter implements ILicenseFormatWriter {
 	/**
 	 * @param version License list version
 	 * @param releaseDate release date for the license list
-	 * @param markdownFile Markdown formated file written by this class
+	 * @param markdownFile Markdown formatted file written by this class
 	 */
 	public LicenseMarkdownFormatWriter(String version, String releaseDate, File markdownFile) {
 		this.markdownFile = markdownFile;


### PR DESCRIPTION
- Remove Travis CI badge (not active)
- Add TestLicenseXML testDirectory parameter
- Fix typo in usage:
  - licencenseXmlFileOrDir -> licenseXmlFileOrDir
    - This is a parameter name, not a function name, so it is safe to fix it and not breaking existing command lines 
- Fix other typos