### PR TITLE
Use class and file resolvers for Mustache

### DIFF
--- a/src/org/spdx/htmltemplates/ExceptionHtml.java
+++ b/src/org/spdx/htmltemplates/ExceptionHtml.java
@@ -41,8 +41,6 @@ import com.github.mustachejava.MustacheException;
  */
 public class ExceptionHtml {
 
-	static final String TEMPLATE_CLASS_PATH = "resources" + "/" + "htmlTemplate";
-	static final String TEMPLATE_ROOT_PATH = "resources" + File.separator + "htmlTemplate";
 	static final String HTML_TEMPLATE = "ExceptionHTMLTemplate.html";
 
 	Map<String, Object> mustacheMap = new HashMap<>();
@@ -75,31 +73,16 @@ public class ExceptionHtml {
 	public void writeToFile(File exceptionHtmlFile,
 			String exceptionHtmlTocReference) throws IOException, MustacheException {
 		mustacheMap.put("exceptionTocReference", exceptionHtmlTocReference);
-		FileOutputStream stream = null;
-		OutputStreamWriter writer = null;
-		if (!exceptionHtmlFile.exists()) {
+        if (!exceptionHtmlFile.exists()) {
 			if (!exceptionHtmlFile.createNewFile()) {
 				throw(new IOException("Can not create new file "+exceptionHtmlFile.getName()));
 			}
 		}
-		String templateDirName = TEMPLATE_ROOT_PATH;
-		File templateDirectoryRoot = new File(templateDirName);
-		if (!(templateDirectoryRoot.exists() && templateDirectoryRoot.isDirectory())) {
-			templateDirName = TEMPLATE_CLASS_PATH;
-		}
-		try {
-			stream = new FileOutputStream(exceptionHtmlFile);
-			writer = new OutputStreamWriter(stream, "UTF-8");
-			DefaultMustacheFactory builder = new DefaultMustacheFactory(templateDirName);
-			Mustache mustache = builder.compile(HTML_TEMPLATE);
-	        mustache.execute(writer, mustacheMap);
-		} finally {
-			if (writer != null) {
-				writer.close();
-			}
-			if (stream != null) {
-				stream.close();
-			}
-		}
+
+        try (FileOutputStream stream = new FileOutputStream(exceptionHtmlFile); OutputStreamWriter writer = new OutputStreamWriter(stream, "UTF-8")) {
+            DefaultMustacheFactory builder = new DefaultMustacheFactory(Utility.getMustacheResolver());
+            Mustache mustache = builder.compile(HTML_TEMPLATE);
+            mustache.execute(writer, mustacheMap);
+        }
 	}
 }

--- a/src/org/spdx/htmltemplates/ExceptionHtmlToc.java
+++ b/src/org/spdx/htmltemplates/ExceptionHtmlToc.java
@@ -40,8 +40,6 @@ import com.github.mustachejava.MustacheException;
  *
  */
 public class ExceptionHtmlToc {
-	static final String TEMPLATE_CLASS_PATH = "resources" + "/" + "htmlTemplate";
-	static final String TEMPLATE_ROOT_PATH = "resources" + File.separator + "htmlTemplate";
 	static final String HTML_TEMPLATE = "ExceptionsTocHTMLTemplate.html";
 
 	public static class DeprecatedExceptionRow {
@@ -257,32 +255,16 @@ public class ExceptionHtmlToc {
 		});
 		mustacheMap.put("listedExceptions", exceptions);
 		mustacheMap.put("deprecatedExceptions", deprecatedExceptions);
-		FileOutputStream stream = null;
-		OutputStreamWriter writer = null;
-		if (!exceptionTocFile.exists()) {
+        if (!exceptionTocFile.exists()) {
 			if (!exceptionTocFile.createNewFile()) {
 				throw(new IOException("Can not create new file "+exceptionTocFile.getName()));
 			}
 		}
-		String templateDirName = TEMPLATE_ROOT_PATH;
-		File templateDirectoryRoot = new File(templateDirName);
-		if (!(templateDirectoryRoot.exists() && templateDirectoryRoot.isDirectory())) {
-			templateDirName = TEMPLATE_CLASS_PATH;
-		}
-		try {
-			stream = new FileOutputStream(exceptionTocFile);
-			writer = new OutputStreamWriter(stream, "UTF-8");
-			DefaultMustacheFactory builder = new DefaultMustacheFactory(templateDirName);
-			Mustache mustache = builder.compile(HTML_TEMPLATE);
-	        mustache.execute(writer, mustacheMap);
-		} finally {
-			if (writer != null) {
-				writer.close();
-			}
-			if (stream != null) {
-				stream.close();
-			}
-		}
+        try (FileOutputStream stream = new FileOutputStream(exceptionTocFile); OutputStreamWriter writer = new OutputStreamWriter(stream, "UTF-8")) {
+            DefaultMustacheFactory builder = new DefaultMustacheFactory(Utility.getMustacheResolver());
+            Mustache mustache = builder.compile(HTML_TEMPLATE);
+            mustache.execute(writer, mustacheMap);
+        }
 	}
 
 }

--- a/src/org/spdx/htmltemplates/LicenseHTMLFile.java
+++ b/src/org/spdx/htmltemplates/LicenseHTMLFile.java
@@ -50,8 +50,6 @@ import com.github.mustachejava.MustacheException;
  */
 public class LicenseHTMLFile {
 
-	static final String TEMPLATE_CLASS_PATH = "resources" + "/" + "htmlTemplate";
-	static final String TEMPLATE_ROOT_PATH = "resources" + File.separator + "htmlTemplate";
 	static final String TEMPLATE_FILE_NAME = "LicenseHTMLTemplate.html";
 
 	static Comparator<CrossRef> licenseComparator =	new Comparator<CrossRef>() {
@@ -176,15 +174,10 @@ public class LicenseHTMLFile {
 				throw(new IOException("Can not create new file "+htmlFile.getName()));
 			}
 		}
-		String templateDirName = TEMPLATE_ROOT_PATH;
-		File templateDirectoryRoot = new File(templateDirName);
-		if (!(templateDirectoryRoot.exists() && templateDirectoryRoot.isDirectory())) {
-			templateDirName = TEMPLATE_CLASS_PATH;
-		}
 		try {
 			stream = new FileOutputStream(htmlFile);
 			writer = new OutputStreamWriter(stream, "UTF-8");
-			DefaultMustacheFactory builder = new DefaultMustacheFactory(templateDirName);
+			DefaultMustacheFactory builder = new DefaultMustacheFactory(Utility.getMustacheResolver());
 	        Map<String, Object> mustacheMap = buildMustachMap();
 	        Mustache mustache = builder.compile(TEMPLATE_FILE_NAME);
 	        mustache.execute(writer, mustacheMap);

--- a/src/org/spdx/htmltemplates/LicenseTOCHTMLFile.java
+++ b/src/org/spdx/htmltemplates/LicenseTOCHTMLFile.java
@@ -40,8 +40,6 @@ import com.github.mustachejava.MustacheException;
  */
 public class LicenseTOCHTMLFile {
 
-	static final String TEMPLATE_CLASS_PATH = "resources" + "/" + "htmlTemplate";
-	static final String TEMPLATE_ROOT_PATH = "resources" + File.separator + "htmlTemplate";
 	static final String HTML_TEMPLATE = "TocHTMLTemplate.html";
 
 	public static class DeprecatedLicense {
@@ -136,7 +134,7 @@ public class LicenseTOCHTMLFile {
 		private String refNumber;
 		private String licenseId;
 		private String osiApproved;
-		private String fsfLibre;
+		private final String fsfLibre;
 		private String licenseName;
 
 		public ListedSpdxLicense() {
@@ -271,37 +269,22 @@ public class LicenseTOCHTMLFile {
 	}
 
 	public void writeToFile(File htmlFile) throws IOException, MustacheException {
-		FileOutputStream stream = null;
-		OutputStreamWriter writer = null;
-		if (!htmlFile.exists()) {
+        if (!htmlFile.exists()) {
 			if (!htmlFile.createNewFile()) {
 				throw(new IOException("Can not create new file "+htmlFile.getName()));
 			}
 		}
-		String templateDirName = TEMPLATE_ROOT_PATH;
-		File templateDirectoryRoot = new File(templateDirName);
-		if (!(templateDirectoryRoot.exists() && templateDirectoryRoot.isDirectory())) {
-			templateDirName = TEMPLATE_CLASS_PATH;
-		}
-		try {
-			stream = new FileOutputStream(htmlFile);
-			writer = new OutputStreamWriter(stream, "UTF-8");
-			DefaultMustacheFactory builder = new DefaultMustacheFactory(templateDirName);
-	        Map<String, Object> mustacheMap = buildMustachMap();
-	        Mustache mustache = builder.compile(HTML_TEMPLATE);
-	        mustache.execute(writer, mustacheMap);
-		} finally {
-			if (writer != null) {
-				writer.close();
-			}
-			if (stream != null) {
-				stream.close();
-			}
-		}
+
+        try (FileOutputStream stream = new FileOutputStream(htmlFile); OutputStreamWriter writer = new OutputStreamWriter(stream, "UTF-8")) {
+            DefaultMustacheFactory builder = new DefaultMustacheFactory(Utility.getMustacheResolver());
+            Map<String, Object> mustacheMap = buildMustachMap();
+            Mustache mustache = builder.compile(HTML_TEMPLATE);
+            mustache.execute(writer, mustacheMap);
+        }
 	}
 	/**
 	 * Build the a hash map to map the variables in the template to the values
-	 * @return
+	 * @return the map build from the license
 	 */
 	private Map<String, Object> buildMustachMap() {
 		Map<String, Object> retval = new HashMap<>();

--- a/src/org/spdx/htmltemplates/Utility.java
+++ b/src/org/spdx/htmltemplates/Utility.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Source Auditor Inc. 2025.
+ *
+ */
+
+package org.spdx.htmltemplates;
+
+import com.github.mustachejava.MustacheResolver;
+import com.github.mustachejava.resolver.ClasspathResolver;
+import com.github.mustachejava.resolver.FileSystemResolver;
+
+import java.io.File;
+
+/**
+ * Utility class for HTML templates - static methods for common code across different templates
+ */
+public class Utility {
+
+    static final String TEMPLATE_CLASS_PATH = "resources" + "/" + "htmlTemplate";
+    static final String TEMPLATE_ROOT_PATH = "resources" + File.separator + "htmlTemplate";
+
+    /**
+     * Gets the file system based resolver if it exists, otherwise returns a class path resolver
+     * @return resolver based on if the file system match exists
+     */
+    static MustacheResolver getMustacheResolver() {
+        File templateDirectoryRoot = new File(TEMPLATE_ROOT_PATH);
+        if (templateDirectoryRoot.exists() && templateDirectoryRoot.isDirectory()) {
+            return new FileSystemResolver(templateDirectoryRoot);
+        } else {
+            return new ClasspathResolver(TEMPLATE_CLASS_PATH);
+        }
+    }
+}


### PR DESCRIPTION
Resolves an issue where file system HTML templates causes an error if run on a windows platform