### PR TITLE
Vendor FSF license status JSON file from fsf-api

### DIFF
--- a/resources/licenses-full.json
+++ b/resources/licenses-full.json
@@ -1,28 +1,5 @@
 {
-  "@context": {
-    "id": {
-      "@id": "schema:identifier"
-    },
-    "identifiers": {
-      "@container": "@index",
-      "@id": "schema:identifier"
-    },
-    "licenses": {
-      "@container": "@index",
-      "@id": "https://spdx.github.io/fsf-api/schema/license.jsonld"
-    },
-    "name": {
-      "@id": "schema:name"
-    },
-    "schema": "https://schema.org/",
-    "tags": {
-      "@id": "schema:keywords"
-    },
-    "uris": {
-      "@container": "@list",
-      "@id": "schema:url"
-    }
-  },
+  "@context": "https://spdx.github.io/fsf-api/schema/licenses.jsonld",
   "licenses": {
     "ACDL": {
       "id": "ACDL",
@@ -32,13 +9,15 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#ACDL",
-        "http://fedoraproject.org/wiki/Licensing/Common_Documentation_License"
+        "https://directory.fsf.org/wiki/License:ACDL-1.0"
       ]
     },
     "AGPLv1.0": {
       "id": "AGPLv1.0",
       "identifiers": {
         "spdx": [
+          "AGPL-1.0-or-later",
+          "AGPL-1.0-only",
           "AGPL-1.0"
         ]
       },
@@ -48,7 +27,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#AGPLv1.0",
-        "http://directory.fsf.org/wiki/License:AGPLv1"
+        "https://directory.fsf.org/wiki/License:AGPLv1"
       ]
     },
     "AGPLv3.0": {
@@ -93,7 +72,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#AcademicFreeLicense",
-        "http://directory.fsf.org/wiki/License:AFLv3"
+        "https://directory.fsf.org/wiki/License:AFLv3"
       ]
     },
     "AcademicFreeLicense1.2": {
@@ -109,7 +88,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#AcademicFreeLicense",
-        "http://directory.fsf.org/wiki/License:AFLv3"
+        "https://directory.fsf.org/wiki/License:AFLv3"
       ]
     },
     "AcademicFreeLicense2.0": {
@@ -125,7 +104,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#AcademicFreeLicense",
-        "http://directory.fsf.org/wiki/License:AFLv3"
+        "https://directory.fsf.org/wiki/License:AFLv3"
       ]
     },
     "AcademicFreeLicense2.1": {
@@ -141,7 +120,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#AcademicFreeLicense",
-        "http://directory.fsf.org/wiki/License:AFLv3"
+        "https://directory.fsf.org/wiki/License:AFLv3"
       ]
     },
     "AcademicFreeLicense3.0": {
@@ -157,7 +136,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#AcademicFreeLicense",
-        "http://directory.fsf.org/wiki/License:AFLv3"
+        "https://directory.fsf.org/wiki/License:AFLv3"
       ]
     },
     "Aladdin": {
@@ -211,7 +190,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#ArtisticLicense",
-        "http://directory.fsf.org/wiki/License:Artistic_v1.0"
+        "https://directory.fsf.org/wiki/License:Artistic_v1.0"
       ]
     },
     "ArtisticLicense2": {
@@ -229,7 +208,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#ArtisticLicense2",
-        "http://directory.fsf.org/wiki/License:ArtisticLicense2.0"
+        "https://directory.fsf.org/wiki/License:ArtisticLicense2.0"
       ]
     },
     "BerkeleyDB": {
@@ -247,7 +226,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#BerkeleyDB",
-        "http://directory.fsf.org/wiki/License:Sleepycat"
+        "https://directory.fsf.org/wiki/License:Sleepycat"
       ]
     },
     "CC-BY-NC-1.0": {
@@ -420,7 +399,7 @@
           "CC0-1.0"
         ]
       },
-      "name": "CC0",
+      "name": "CC0 1.0 Universal",
       "tags": [
         "gpl-2-compatible",
         "gpl-3-compatible",
@@ -428,7 +407,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#CC0",
-        "http://directory.fsf.org/wiki/License:CC0"
+        "https://creativecommons.org/publicdomain/zero/1.0/"
       ]
     },
     "CDDL": {
@@ -444,7 +423,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#CDDL",
-        "http://directory.fsf.org/wiki/License:CDDLv1.0"
+        "https://directory.fsf.org/wiki/License:CDDLv1.0"
       ]
     },
     "CPAL": {
@@ -494,7 +473,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#CeCILL-B",
-        "https://cecill.info/licences/Licence_CeCILL-B_V1-en.html"
+        "https://spdx.org/licenses/CECILL-B"
       ]
     },
     "CeCILL-C": {
@@ -510,7 +489,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#CeCILL-C",
-        "https://cecill.info/licences/Licence_CeCILL-C_V1-en.html"
+        "https://spdx.org/licenses/CECILL-C"
       ]
     },
     "ClarifiedArtistic": {
@@ -544,7 +523,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#CommonPublicLicense10",
-        "http://directory.fsf.org/wiki/License:CPLv1.0"
+        "https://directory.fsf.org/wiki/License:CPLv1.0"
       ]
     },
     "Condor": {
@@ -560,7 +539,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#Condor",
-        "http://directory.fsf.org/wiki?title=License:Condor1.1"
+        "https://directory.fsf.org/wiki?title=License:Condor1.1"
       ]
     },
     "CryptixGeneralLicense": {
@@ -573,7 +552,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#CryptixGeneralLicense",
-        "http://directory.fsf.org/wiki/License:CryptixGL"
+        "https://directory.fsf.org/wiki/License:CryptixGL"
       ]
     },
     "DOR": {
@@ -601,7 +580,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#ECL2.0",
-        "http://directory.fsf.org/wiki/License:ECL2.0"
+        "https://directory.fsf.org/wiki/License:ECL2.0"
       ]
     },
     "EPL": {
@@ -617,7 +596,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#EPL",
-        "http://directory.fsf.org/wiki/License:EPLv1.0"
+        "https://directory.fsf.org/wiki/License:EPLv1.0"
       ]
     },
     "EPL2": {
@@ -651,7 +630,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#EUDataGrid",
-        "http://directory.fsf.org/wiki/License:EUDataGrid"
+        "https://directory.fsf.org/wiki/License:EUDataGrid"
       ]
     },
     "EUPL-1.1": {
@@ -667,7 +646,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#EUPL-1.1",
-        "http://directory.fsf.org/wiki/License:EUPLv1.1"
+        "https://directory.fsf.org/wiki/License:EUPLv1.1"
       ]
     },
     "EUPL-1.2": {
@@ -683,7 +662,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#EUPL-1.2",
-        "http://directory.fsf.org/wiki/License:EUPLv1.2"
+        "https://directory.fsf.org/wiki/License:EUPLv1.2"
       ]
     },
     "Eiffel": {
@@ -701,7 +680,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#Eiffel",
-        "http://directory.fsf.org/wiki/License:EFLv2"
+        "https://directory.fsf.org/wiki/License:EFLv2"
       ]
     },
     "Expat": {
@@ -719,7 +698,25 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#Expat",
-        "http://directory.fsf.org/wiki/License:Expat"
+        "https://directory.fsf.org/wiki/License:Expat"
+      ]
+    },
+    "Expat0": {
+      "id": "Expat0",
+      "identifiers": {
+        "spdx": [
+          "MIT-0"
+        ]
+      },
+      "name": "Expat No Attribution License",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Expat0",
+        "https://directory.fsf.org/wiki/License:Expat_No_Attribution"
       ]
     },
     "FDLv1.1": {
@@ -811,8 +808,9 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#FreeBSD",
-        "http://directory.fsf.org/wiki?title=License:FreeBSD",
-        "https://www.gnu.org/licenses/license-list.html#FreeBSDDL"
+        "https://directory.fsf.org/wiki?title=License:FreeBSD",
+        "https://www.gnu.org/licenses/license-list.html#FreeBSDDL",
+        "https://directory.fsf.org/wiki?title=License:FreeBSD-DL"
       ]
     },
     "GNUAllPermissive": {
@@ -872,7 +870,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#GPL-PA",
-        "http://directory.fsf.org/wiki/License:GPL-PA"
+        "https://directory.fsf.org/wiki/License:GPL-PA"
       ]
     },
     "GPLFonts": {
@@ -947,7 +945,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#HPND",
-        "http://directory.fsf.org/wiki/License:Historical_Permission_Notice_and_Disclaimer"
+        "https://directory.fsf.org/wiki/License:Historical_Permission_Notice_and_Disclaimer"
       ]
     },
     "IBMPL": {
@@ -963,7 +961,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#IBMPL",
-        "http://directory.fsf.org/wiki/License:IBMPLv1.0"
+        "https://directory.fsf.org/wiki/License:IBMPLv1.0"
       ]
     },
     "IPAFONT": {
@@ -979,7 +977,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#IPAFONT",
-        "http://directory.fsf.org/wiki/License:IPA_Font_License"
+        "https://directory.fsf.org/wiki/License:IPA_Font_License"
       ]
     },
     "ISC": {
@@ -997,7 +995,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#ISC",
-        "http://directory.fsf.org/wiki/License:ISC"
+        "https://directory.fsf.org/wiki/License:ISC"
       ]
     },
     "JSON": {
@@ -1013,7 +1011,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#JSON",
-        "http://directory.fsf.org/wiki/License:JSON"
+        "https://directory.fsf.org/wiki/License:JSON"
       ]
     },
     "Jahia": {
@@ -1081,7 +1079,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#LPPL-1.2",
-        "http://directory.fsf.org/wiki/License:LPPLv1.2"
+        "https://directory.fsf.org/wiki/License:LPPLv1.2"
       ]
     },
     "LPPL-1.3a": {
@@ -1097,7 +1095,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#LPPL-1.3a",
-        "http://directory.fsf.org/wiki/License:LPPLv1.3a"
+        "https://directory.fsf.org/wiki/License:LPPLv1.3a"
       ]
     },
     "Lha": {
@@ -1108,7 +1106,18 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#Lha",
-        "http://directory.fsf.org/wiki/License:Lha"
+        "https://directory.fsf.org/wiki/License:Lha"
+      ]
+    },
+    "Llama": {
+      "id": "Llama",
+      "name": "Llama 3.1 Community License Agreement and Llama 3.1 Acceptable Use Policy",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Llama",
+        "https://directory.fsf.org/wiki/License:Llama"
       ]
     },
     "MPL": {
@@ -1124,7 +1133,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#MPL",
-        "http://directory.fsf.org/wiki/License:MPLv1.1"
+        "https://directory.fsf.org/wiki/License:MPLv1.1"
       ]
     },
     "MPL-2.0": {
@@ -1142,7 +1151,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#MPL-2.0",
-        "http://directory.fsf.org/wiki/License:MPLv2.0"
+        "https://directory.fsf.org/wiki/License:MPLv2.0"
       ]
     },
     "ModifiedBSD": {
@@ -1160,7 +1169,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#ModifiedBSD",
-        "http://directory.fsf.org/wiki/License:BSD_3Clause"
+        "https://directory.fsf.org/wiki/License:BSD_3Clause"
       ]
     },
     "Ms-SS": {
@@ -1171,7 +1180,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#Ms-SS",
-        "http://directory.fsf.org/wiki/License:Ms-SS"
+        "https://directory.fsf.org/wiki/License:Ms-SS"
       ]
     },
     "NASA": {
@@ -1187,7 +1196,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#NASA",
-        "http://directory.fsf.org/wiki/License:NASA-OSA_v1.3"
+        "https://directory.fsf.org/wiki/License:NASA-OSA_v1.3"
       ]
     },
     "NCSA": {
@@ -1205,7 +1214,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#NCSA",
-        "http://directory.fsf.org/wiki/License:IllinoisNCSA"
+        "https://directory.fsf.org/wiki/License:IllinoisNCSA"
       ]
     },
     "NOSL": {
@@ -1221,7 +1230,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#NOSL",
-        "http://directory.fsf.org/wiki/License:NOSLv1.0"
+        "https://directory.fsf.org/wiki/License:NOSLv1.0"
       ]
     },
     "NPL-1.0": {
@@ -1237,7 +1246,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#NPL",
-        "http://directory.fsf.org/wiki?title=License:NPLv1.1"
+        "https://directory.fsf.org/wiki?title=License:NPLv1.1"
       ]
     },
     "NPL-1.1": {
@@ -1253,7 +1262,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#NPL",
-        "http://directory.fsf.org/wiki?title=License:NPLv1.1"
+        "https://directory.fsf.org/wiki?title=License:NPLv1.1"
       ]
     },
     "NoLicense": {
@@ -1284,7 +1293,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#Nokia",
-        "http://directory.fsf.org/wiki/License:NokOSv1.0a"
+        "https://directory.fsf.org/wiki/License:NokOSv1.0a"
       ]
     },
     "ODbl": {
@@ -1300,7 +1309,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#ODbl",
-        "http://directory.fsf.org/wiki/License:ODbl"
+        "https://directory.fsf.org/wiki/License:ODbl"
       ]
     },
     "OSL-1.0": {
@@ -1316,7 +1325,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#OSL",
-        "http://directory.fsf.org/wiki/License:OSLv3.0"
+        "https://directory.fsf.org/wiki/License:OSLv3.0"
       ]
     },
     "OSL-1.1": {
@@ -1332,7 +1341,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#OSL",
-        "http://directory.fsf.org/wiki/License:OSLv3.0"
+        "https://directory.fsf.org/wiki/License:OSLv3.0"
       ]
     },
     "OSL-2.0": {
@@ -1348,7 +1357,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#OSL",
-        "http://directory.fsf.org/wiki/License:OSLv3.0"
+        "https://directory.fsf.org/wiki/License:OSLv3.0"
       ]
     },
     "OSL-2.1": {
@@ -1364,7 +1373,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#OSL",
-        "http://directory.fsf.org/wiki/License:OSLv3.0"
+        "https://directory.fsf.org/wiki/License:OSLv3.0"
       ]
     },
     "OSL-3.0": {
@@ -1380,7 +1389,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#OSL",
-        "http://directory.fsf.org/wiki/License:OSLv3.0"
+        "https://directory.fsf.org/wiki/License:OSLv3.0"
       ]
     },
     "OculusRiftSDK": {
@@ -1391,7 +1400,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#OculusRiftSDK",
-        "http://directory.fsf.org/wiki/License:Oculus_VR_Rift_SDK_License"
+        "https://directory.fsf.org/wiki/License:Oculus_VR_Rift_SDK_License"
       ]
     },
     "OpenContentL": {
@@ -1418,7 +1427,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#OpenPublicL",
-        "http://directory.fsf.org/wiki/License:OpenPLv1.0"
+        "https://directory.fsf.org/wiki/License:OpenPLv1.0"
       ]
     },
     "OpenPublicationL": {
@@ -1429,7 +1438,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#OpenPublicationL",
-        "https://opencontent.org/openpub/"
+        "https://directory.fsf.org/wiki/License:Open_Publication_License_v1.0"
       ]
     },
     "OpenSSL": {
@@ -1445,7 +1454,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#OpenSSL",
-        "http://directory.fsf.org/wiki/License:OpenSSL"
+        "https://directory.fsf.org/wiki/License:OpenSSL"
       ]
     },
     "OriginalBSD": {
@@ -1461,7 +1470,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#OriginalBSD",
-        "http://directory.fsf.org/wiki/License:BSD_4Clause"
+        "https://directory.fsf.org/wiki/License:BSD_4Clause"
       ]
     },
     "PHP-3.01": {
@@ -1477,7 +1486,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#PHP-3.01",
-        "http://directory.fsf.org/wiki/License:PHPv3.01"
+        "https://directory.fsf.org/wiki/License:PHPv3.01"
       ]
     },
     "PINE": {
@@ -1488,7 +1497,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#PINE",
-        "http://directory.fsf.org/wiki/License:PINE"
+        "https://directory.fsf.org/wiki/License:PINE"
       ]
     },
     "PPL": {
@@ -1499,7 +1508,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#PPL",
-        "http://directory.fsf.org/wiki/License:PPL"
+        "https://directory.fsf.org/wiki/License:PPL"
       ]
     },
     "PPL3a": {
@@ -1533,7 +1542,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#Phorum",
-        "http://directory.fsf.org/wiki/License:Phorum2.0"
+        "https://directory.fsf.org/wiki/License:Phorum2.0"
       ]
     },
     "Plan9": {
@@ -1557,7 +1566,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#PublicDomain",
-        "http://directory.fsf.org/wiki/License:PublicDomain"
+        "https://directory.fsf.org/wiki/License:PublicDomain"
       ]
     },
     "Python": {
@@ -1570,7 +1579,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#Python",
-        "http://directory.fsf.org/wiki?title=License:Python2.0.1"
+        "https://directory.fsf.org/wiki?title=License:Python2.0.1"
       ]
     },
     "Python1.6a2": {
@@ -1583,7 +1592,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#Python1.6a2",
-        "http://directory.fsf.org/wiki?title=License:Python1.6a2"
+        "https://directory.fsf.org/wiki?title=License:Python1.6a2"
       ]
     },
     "Python1.6b1": {
@@ -1594,7 +1603,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#PythonOld",
-        "http://directory.fsf.org/wiki/License:Python1.6b1"
+        "https://directory.fsf.org/wiki/License:Python1.6b1"
       ]
     },
     "Python2.0": {
@@ -1610,7 +1619,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#PythonOld",
-        "http://directory.fsf.org/wiki/License:Python1.6b1"
+        "https://directory.fsf.org/wiki/License:Python1.6b1"
       ]
     },
     "Python2.1": {
@@ -1621,7 +1630,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#PythonOld",
-        "http://directory.fsf.org/wiki/License:Python1.6b1"
+        "https://directory.fsf.org/wiki/License:Python1.6b1"
       ]
     },
     "QPL": {
@@ -1637,7 +1646,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#QPL",
-        "http://directory.fsf.org/wiki/License:QPLv1.0"
+        "https://directory.fsf.org/wiki/License:QPLv1.0"
       ]
     },
     "RPL": {
@@ -1648,7 +1657,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#RPL",
-        "http://directory.fsf.org/wiki/License:ReciprocalPLv1.3"
+        "https://directory.fsf.org/wiki/License:ReciprocalPLv1.3"
       ]
     },
     "RPSL": {
@@ -1664,7 +1673,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#RPSL",
-        "http://directory.fsf.org/wiki/License:RPSLv1.0"
+        "https://directory.fsf.org/wiki/License:RPSLv1.0"
       ]
     },
     "Ruby": {
@@ -1682,7 +1691,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#Ruby",
-        "http://directory.fsf.org/wiki/License:Ruby"
+        "https://directory.fsf.org/wiki/License:Ruby"
       ]
     },
     "SGIFreeB": {
@@ -1700,7 +1709,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#SGIFreeB",
-        "http://directory.fsf.org/wiki/License:SGIFreeBv2"
+        "https://directory.fsf.org/wiki/License:SGIFreeBv2"
       ]
     },
     "SILOFL-1.0": {
@@ -1716,7 +1725,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#SILOFL",
-        "http://directory.fsf.org/wiki/SIL_Open_Font_License_1.1"
+        "https://directory.fsf.org/wiki/SIL_Open_Font_License_1.1"
       ]
     },
     "SILOFL-1.1": {
@@ -1732,7 +1741,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#SILOFL",
-        "http://directory.fsf.org/wiki/SIL_Open_Font_License_1.1"
+        "https://directory.fsf.org/wiki/SIL_Open_Font_License_1.1"
       ]
     },
     "SISSL": {
@@ -1754,7 +1763,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#SML",
-        "http://directory.fsf.org/wiki/License:SimpleM"
+        "https://directory.fsf.org/wiki/License:SimpleM"
       ]
     },
     "SPL": {
@@ -1770,7 +1779,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#SPL",
-        "http://directory.fsf.org/wiki/License:SPLv1.0"
+        "https://directory.fsf.org/wiki/License:SPLv1.0"
       ]
     },
     "Scilab": {
@@ -1781,7 +1790,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#Scilab",
-        "http://directory.fsf.org/wiki/License:Scilab-old"
+        "https://directory.fsf.org/wiki/License:Scilab-old"
       ]
     },
     "Scratch": {
@@ -1792,7 +1801,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#Scratch",
-        "http://directory.fsf.org/wiki/License:Scratch"
+        "https://directory.fsf.org/wiki/License:Scratch"
       ]
     },
     "Squeak": {
@@ -1803,7 +1812,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#Squeak",
-        "http://directory.fsf.org/wiki/License:Squeak-old"
+        "https://directory.fsf.org/wiki/License:Squeak-old"
       ]
     },
     "StandardMLofNJ": {
@@ -1822,7 +1831,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#StandardMLofNJ",
-        "http://directory.fsf.org/wiki/License:StandardMLofNJ"
+        "https://directory.fsf.org/wiki/License:StandardMLofNJ"
       ]
     },
     "SunCommunitySourceLicense": {
@@ -1833,7 +1842,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#SunCommunitySourceLicense",
-        "http://directory.fsf.org/wiki/License:SunCSLv2.8"
+        "https://directory.fsf.org/wiki/License:SunCSLv2.8"
       ]
     },
     "SunSolarisSourceCode": {
@@ -1866,7 +1875,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#Truecrypt-3.0",
-        "http://directory.fsf.org/wiki/License:TrueCrypt"
+        "https://directory.fsf.org/wiki/License:TrueCrypt"
       ]
     },
     "UPL": {
@@ -1884,7 +1893,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#UPL",
-        "http://directory.fsf.org/wiki/License:Universal_Permissive_License"
+        "https://directory.fsf.org/wiki/License:Universal_Permissive_License"
       ]
     },
     "Unicode": {
@@ -1897,7 +1906,25 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#Unicode",
-        "http://directory.fsf.org/wiki/License:Unicode"
+        "https://directory.fsf.org/wiki/License:Unicode"
+      ]
+    },
+    "Unicodev3": {
+      "id": "Unicodev3",
+      "identifiers": {
+        "spdx": [
+          "Unicode-3.0"
+        ]
+      },
+      "name": "Unicode License v3",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Unicodev3",
+        "https://directory.fsf.org/wiki/License:Unicode-v3"
       ]
     },
     "Unlicense": {
@@ -1915,7 +1942,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#Unlicense",
-        "http://directory.fsf.org/wiki/License:TheUnlicense"
+        "https://directory.fsf.org/wiki/License:TheUnlicense"
       ]
     },
     "UtahPublicLicense": {
@@ -1944,7 +1971,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#Vim",
-        "http://directory.fsf.org/wiki/License:Vim7.2"
+        "https://directory.fsf.org/wiki/License:Vim7.2"
       ]
     },
     "W3C": {
@@ -1962,7 +1989,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#W3C",
-        "http://directory.fsf.org/wiki/License:W3C_31Dec2002"
+        "https://directory.fsf.org/wiki/License:W3C_31Dec2002"
       ]
     },
     "WTFPL": {
@@ -2009,7 +2036,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#WebM",
-        "http://directory.fsf.org/wiki/License:WebM"
+        "https://directory.fsf.org/wiki/License:WebM"
       ]
     },
     "X11License": {
@@ -2027,7 +2054,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#X11License",
-        "http://directory.fsf.org/wiki/License:X11"
+        "https://directory.fsf.org/wiki/License:X11"
       ]
     },
     "XFree861.1License": {
@@ -2045,7 +2072,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#XFree861.1License",
-        "http://directory.fsf.org/wiki/License:XFree86_1.1"
+        "https://directory.fsf.org/wiki/License:XFree86_1.1"
       ]
     },
     "YaST": {
@@ -2072,7 +2099,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#Yahoo",
-        "http://directory.fsf.org/wiki/License:YPLv1.1"
+        "https://directory.fsf.org/wiki/License:YPLv1.1"
       ]
     },
     "ZLib": {
@@ -2091,7 +2118,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#ZLib",
-        "http://directory.fsf.org/wiki/License:Zlib"
+        "https://directory.fsf.org/wiki/License:Zlib"
       ]
     },
     "Zend": {
@@ -2107,7 +2134,25 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#Zend",
-        "http://directory.fsf.org/wiki/License:ZELv2.0"
+        "https://directory.fsf.org/wiki/License:ZELv2.0"
+      ]
+    },
+    "Zero-BSD": {
+      "id": "Zero-BSD",
+      "identifiers": {
+        "spdx": [
+          "0BSD"
+        ]
+      },
+      "name": "Zero-clause BSD license",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Zero-BSD",
+        "https://directory.fsf.org/wiki?title=License:Zero-Clause_BSD"
       ]
     },
     "Zimbra": {
@@ -2152,7 +2197,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#Zope2.0",
-        "http://directory.fsf.org/wiki?title=License:ZopePLv2.1"
+        "https://directory.fsf.org/wiki?title=License:ZopePLv2.1"
       ]
     },
     "Zope2.1": {
@@ -2170,7 +2215,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#Zope2.0",
-        "http://directory.fsf.org/wiki?title=License:ZopePLv2.1"
+        "https://directory.fsf.org/wiki?title=License:ZopePLv2.1"
       ]
     },
     "anticapitalist": {
@@ -2180,7 +2225,8 @@
         "non-free"
       ],
       "uris": [
-        "https://www.gnu.org/licenses/license-list.html#anticapitalist"
+        "https://www.gnu.org/licenses/license-list.html#anticapitalist",
+        "https://directory.fsf.org/wiki/License:ANTI-1.4"
       ]
     },
     "apache1": {
@@ -2196,7 +2242,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#apache1",
-        "http://directory.fsf.org/wiki/License:Apache1.0"
+        "https://directory.fsf.org/wiki/License:Apache1.0"
       ]
     },
     "apache1.1": {
@@ -2212,7 +2258,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#apache1.1",
-        "http://directory.fsf.org/wiki/License:Apache1.1"
+        "https://directory.fsf.org/wiki/License:Apache1.1"
       ]
     },
     "apache2": {
@@ -2229,7 +2275,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#apache2",
-        "http://directory.fsf.org/wiki/License:Apache2.0"
+        "https://directory.fsf.org/wiki/License:Apache2.0"
       ]
     },
     "apsl1": {
@@ -2245,7 +2291,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#apsl1",
-        "http://directory.fsf.org/wiki/License:APSLv1.x"
+        "https://directory.fsf.org/wiki/License:APSLv1.x"
       ]
     },
     "apsl2": {
@@ -2261,7 +2307,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#apsl2",
-        "http://directory.fsf.org/wiki/License:APSLv2.0"
+        "https://directory.fsf.org/wiki/License:APSLv2.0"
       ]
     },
     "bittorrent": {
@@ -2277,7 +2323,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#bittorrent",
-        "http://directory.fsf.org/wiki/License:BitTorrentOSL1.1"
+        "https://directory.fsf.org/wiki/License:BitTorrentOSL1.1"
       ]
     },
     "boost": {
@@ -2295,7 +2341,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#boost",
-        "http://directory.fsf.org/wiki/License:Boost1.0"
+        "https://directory.fsf.org/wiki/License:Boost1.0"
       ]
     },
     "ccby": {
@@ -2347,7 +2393,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#clearbsd",
-        "http://directory.fsf.org/wiki/License:ClearBSD"
+        "https://directory.fsf.org/wiki/License:ClearBSD"
       ]
     },
     "comclause": {
@@ -2373,7 +2419,8 @@
         "non-free"
       ],
       "uris": [
-        "https://www.gnu.org/licenses/license-list.html#cpol"
+        "https://www.gnu.org/licenses/license-list.html#cpol",
+        "https://directory.fsf.org/wiki/License:CPOL-1.02"
       ]
     },
     "dsl": {
@@ -2400,7 +2447,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#eCos11",
-        "http://directory.fsf.org/wiki/License:ECosPLv1.1"
+        "https://directory.fsf.org/wiki/License:ECosPLv1.1"
       ]
     },
     "eCos2.0": {
@@ -2419,7 +2466,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#eCos2.0",
-        "http://directory.fsf.org/wiki/License:ECos2.0"
+        "https://directory.fsf.org/wiki/License:ECos2.0"
       ]
     },
     "ecfonts": {
@@ -2430,7 +2477,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#ecfonts",
-        "http://directory.fsf.org/wiki/License:LaTeX_ecfonts"
+        "https://directory.fsf.org/wiki/License:LaTeX_ecfonts"
       ]
     },
     "fdk": {
@@ -2441,7 +2488,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#fdk",
-        "http://directory.fsf.org/wiki/License:fdk"
+        "https://directory.fsf.org/wiki/License:fdk"
       ]
     },
     "freetype": {
@@ -2458,7 +2505,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#freetype",
-        "http://directory.fsf.org/wiki/License:FreeType"
+        "https://directory.fsf.org/wiki/License:FreeType"
       ]
     },
     "gnuplot": {
@@ -2474,7 +2521,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#gnuplot",
-        "http://directory.fsf.org/wiki/License:Gnuplot"
+        "https://directory.fsf.org/wiki/License:Gnuplot"
       ]
     },
     "hippocratic": {
@@ -2485,7 +2532,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#hippocratic",
-        "https://web.archive.org/web/20191217000421/https://firstdonoharm.dev/version/1/1/license.txt"
+        "https://directory.fsf.org/wiki/License:THL-1.1"
       ]
     },
     "iMatix": {
@@ -2503,7 +2550,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#iMatix",
-        "http://directory.fsf.org/wiki?title=License:SFL"
+        "https://directory.fsf.org/wiki?title=License:SFL"
       ]
     },
     "ijg": {
@@ -2521,7 +2568,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#ijg",
-        "http://directory.fsf.org/wiki?title=License:JPEG"
+        "https://directory.fsf.org/wiki?title=License:JPEG"
       ]
     },
     "imlib": {
@@ -2539,7 +2586,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#imlib",
-        "http://directory.fsf.org/wiki/License:Imlib2"
+        "https://directory.fsf.org/wiki/License:Imlib2"
       ]
     },
     "informal": {
@@ -2569,7 +2616,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#intel",
-        "http://directory.fsf.org/wiki/License:IntelACPI"
+        "https://directory.fsf.org/wiki/License:IntelACPI"
       ]
     },
     "josl": {
@@ -2580,7 +2627,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#josl",
-        "http://directory.fsf.org/wiki/License:JabberOSLv1.0"
+        "https://directory.fsf.org/wiki/License:JabberOSLv1.0"
       ]
     },
     "ksh93": {
@@ -2607,7 +2654,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#lucent102",
-        "http://directory.fsf.org/wiki/License:LucentPLv1.02"
+        "https://directory.fsf.org/wiki/License:LucentPLv1.02"
       ]
     },
     "ms-pl": {
@@ -2623,7 +2670,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#ms-pl",
-        "http://directory.fsf.org/wiki/License:MsPL"
+        "https://directory.fsf.org/wiki/License:MsPL"
       ]
     },
     "ms-rl": {
@@ -2639,7 +2686,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#ms-rl",
-        "http://directory.fsf.org/wiki/License:MsRL"
+        "https://directory.fsf.org/wiki/License:MsRL"
       ]
     },
     "newOpenLDAP": {
@@ -2657,7 +2704,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#newOpenLDAP",
-        "http://directory.fsf.org/wiki/License:OpenLDAPv2.7"
+        "https://directory.fsf.org/wiki/License:OpenLDAPv2.7"
       ]
     },
     "oldOpenLDAP": {
@@ -2673,7 +2720,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#oldOpenLDAP",
-        "http://directory.fsf.org/wiki/License:OpenLDAPv2.3"
+        "https://directory.fsf.org/wiki/License:OpenLDAPv2.3"
       ]
     },
     "xinetd": {
@@ -2689,7 +2736,7 @@
       ],
       "uris": [
         "https://www.gnu.org/licenses/license-list.html#xinetd",
-        "http://directory.fsf.org/wiki/License:Xinetd"
+        "https://directory.fsf.org/wiki/License:Xinetd"
       ]
     }
   }


### PR DESCRIPTION
Updates the FSF status in the licenses based on the current FSF website as of 18 June 2025.

Fixes #213

Also adds status from MIT-0 and Unicode-3.0