### PR TITLE
[WIP - Do not merge] Change to JSON-formatted expected warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,11 @@
 			<version>2.3</version>
 		</dependency>
 		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.13.1</version>
+		</dependency>
+		<dependency>
 			<groupId>org.spdx</groupId>
 			<artifactId>spdx-rdf-store</artifactId>
 			<version>2.0.0</version>


### PR DESCRIPTION
This is a draft PR for changing to a JSON-formatted version of the `expected-warnings` file. It corresponds to the changes proposed in https://github.com/spdx/license-list-XML/pull/2772.

Please do not merge this until we've gotten the 3.27.0 license list release out the door, which should be within the next day or two.

Please see the PR at https://github.com/spdx/license-list-XML/pull/2772 for the proposed changes to the `expected-warnings` file. This PR for the publisher in turn swaps out the CSV reader for the `gson` JSON reader as a new dependency. 

The code change in this PR then walks through the parsed arrays of related license IDs. For each pair in an array, it creates two new "Duplicates licenses:" entries, one for each ordering of the two IDs. 

In this way, it should work as a drop-in replacement for the existing process for matching warnings. It just means that the "Duplicates licenses:" text lines are generated dynamically from the JSON at publisher run-time, rather than needing to maintain each of the strings in the XML repo's "source" files.

This is the first time in a long time that I've written Java code of any substance, so please take a close read of this and feel free to reject or replace it.  :)  Happy to discuss if you have any questions.

Signed-off-by: Steve Winslow <steve@swinslow.net>