### PR TITLE
Update url to expressions

### DIFF
--- a/resources/htmlTemplate/TocHTMLTemplate.html
+++ b/resources/htmlTemplate/TocHTMLTemplate.html
@@ -142,14 +142,13 @@
 	    
       <ul style="list-style-type: square; padding: 5px;">
 	      <li style="margin:5px 0 5px 10px;"><a href="./exceptions-index.html"><strong>License Exceptions</strong></a> are commonly found exceptions to free and open source licenses, used with the <strong><a href="https://spdx.github.io/spdx-spec/latest/annexes/spdx-license-expressions/">License Expression</a></strong> operator, "WITH" to create a license with an exception. </li>
-            <li style="margin:5px 0 5px 10px;">The <a href="https://spdx.github.io/spdx-spec/latest/annexes/license-matching-guidelines-and-templates/"><strong>matching guidelines</strong></a> define what constitutes a license or exception match. The license text on the HTML pages here will display omitable text in blue and replaceable text in red (see Guideline #2 for more information).</li>
+	      <li style="margin:5px 0 5px 10px;">The <a href="https://spdx.github.io/spdx-spec/latest/annexes/license-matching-guidelines-and-templates/"><strong>matching guidelines</strong></a> define what constitutes a license or exception match. The license text on the HTML pages here will display omitable text in blue and replaceable text in red (see Guideline #2 for more information).</li>
 	      <li style="margin:5px 0 5px 10px;"><a href="https://github.com/spdx/license-list-XML/blob/master/DOCS/license-fields.md"><strong>Explanation of fields</strong></a> used on the SPDX License List</li>
 	      <li style="margin:5px 0 5px 10px;"><a href="https://github.com/spdx/license-list-XML/blob/master/DOCS/license-inclusion-principles.md"><strong>License inclusion principles</strong></a> for adding new licenses or exceptions to the SPDX License List</li>
 	      <li style="margin:5px 0 5px 10px;"><a href="https://github.com/spdx/license-list-XML/blob/master/CONTRIBUTING.md"><strong>Contribute</strong></a> to the project or request a new license</li>
 	      <li style="margin:0px 0 5px 10px;">Use <a href="https://spdx.dev/ids"><strong>short identifiers in your source code</strong></a></li>
 	      <li style="margin:5px 0 5px 10px;"><a href="https://github.com/spdx/license-list-XML"><strong>Github repo</strong></a></li>
-            <li style="margin:5px 0 5px 10px;">Machine readable <a href="https://github.com/spdx/license-list-data"><strong>data files</strong></a> for the SPDX License List</li>
-
+	      <li style="margin:5px 0 5px 10px;">Machine readable <a href="https://github.com/spdx/license-list-data"><strong>data files</strong></a> for the SPDX License List</li>
       </ul>
 
       <p><strong>Version: </strong><code property="spdx:licenseListVersion">{{version}}</code></p>


### PR DESCRIPTION
The expressions link was pointing to the root of the spec, not the section on expressions. This has been fixed in this PR. 

Also, the link to the matching guidelines was pinned to v3.0 of the spec. It has been updated to always point to the latest version.

Closes #222 