### PR TITLE
Add timeouts to Match and isLive reads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,11 @@
 	</properties>
 	<dependencies>
 		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>2.0.17</version>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.13.2</version>

--- a/src/org/spdx/crossref/Live.java
+++ b/src/org/spdx/crossref/Live.java
@@ -51,14 +51,15 @@ public class Live implements Callable<Boolean>  {
 	      // fake request coming from browser
 	      con.setRequestProperty("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36");
 	      con.setRequestMethod("HEAD");
-	      con.setConnectTimeout(8500);
+	      con.setConnectTimeout(30000);
+		  con.setReadTimeout(30000);
 	      int responseCode = con.getResponseCode();
 	      return (responseCode == HttpURLConnection.HTTP_OK || responseCode == HttpURLConnection.HTTP_NOT_MODIFIED
 	    		  || responseCode == HttpURLConnection.HTTP_MOVED_PERM || responseCode == HttpURLConnection.HTTP_MOVED_TEMP);
 	    } catch (UnknownHostException e) {
 	    	return false;
 	    } catch (Exception e) {
-	    	logger.warn("Failed checking live status.",e.getMessage());
+	    	logger.warn("Failed checking live status for URL {}: {}", URLName, e.getMessage());
 	        return false;
 	    }
 	  }

--- a/src/org/spdx/crossref/Match.java
+++ b/src/org/spdx/crossref/Match.java
@@ -46,11 +46,12 @@ public class Match implements Callable<String> {
 	 */
     public static String checkMatch(String url, SpdxListedLicense license){
     	try {
-			Document doc = Jsoup.connect(url).get();
+			Document doc = Jsoup.connect(url).timeout(30000).get();
 			String bodyText = doc.body().text();
 			return String.valueOf(LicenseCompareHelper.isStandardLicenseWithinText(bodyText, license));
 		} catch (IOException e) {
-			logger.warn("IO exception comparing license text for license ID "+license.getLicenseId()+" and URL "+url);
+			logger.warn("IO exception comparing license text for license ID {} and URL {}: {}", url,
+					license.getLicenseId(), e.getMessage());
 			return String.valueOf(false);
 		}
 	}

--- a/src/org/spdx/licensexml/XmlLicenseProviderWithCrossRefDetails.java
+++ b/src/org/spdx/licensexml/XmlLicenseProviderWithCrossRefDetails.java
@@ -94,7 +94,7 @@ public class XmlLicenseProviderWithCrossRefDetails extends XmlLicenseProvider {
 			
 			ListedLicenseContainer retval = readyLicense.getKey();
 			try {
-				for (CrossRef crossRef:readyLicense.getValue().get(2, TimeUnit.MINUTES)) {
+				for (CrossRef crossRef:readyLicense.getValue().get(5, TimeUnit.MINUTES)) {
 					retval.getV2ListedLicense().getCrossRef().add(crossRef);
 				}
 				


### PR DESCRIPTION
Fixes #230

Also ups the timeout values to minimize the errors.

Add simple logging to the classpath.  This will make the utility much more chatty.

Log level default is set to INFO.

See https://www.slf4j.org/api/org/slf4j/simple/SimpleLogger.html to change the logging level.