### PR TITLE
Don't require exact match on ignored warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,17 +95,17 @@
 		<dependency>
 			<groupId>org.spdx</groupId>
 			<artifactId>spdx-rdf-store</artifactId>
-			<version>2.0.1</version>
+			<version>2.0.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.spdx</groupId>
 			<artifactId>java-spdx-library</artifactId>
-			<version>2.0.1</version>
+			<version>2.0.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.spdx</groupId>
 			<artifactId>spdx-v3jsonld-store</artifactId>
-			<version>1.0.1</version>
+			<version>1.0.2</version>
 		</dependency>
 	</dependencies>
 	<profiles>


### PR DESCRIPTION
FYI @xsuchy @swinslow - I'm after this merge, the ignored warnings file will ignore any warnings that ~start with~ the string in the JSON warnings file rather than requiring a match to the entire string.

This will allow ignoring a class of warnings such as the URL fetches timing out (which happened during my local testing).