### PR TITLE
Update user-agent string to a descriptive one for the tool

### DIFF
--- a/src/org/spdx/crossref/Live.java
+++ b/src/org/spdx/crossref/Live.java
@@ -39,7 +39,7 @@ public class Live implements Callable<Boolean>  {
     public Live(String url) {
         this.url = url;
     }
-	
+
     /**
 	 * @param URLName the url in string form
 	 * @return true/false if the url is live or not
@@ -49,7 +49,7 @@ public class Live implements Callable<Boolean>  {
 	      HttpURLConnection.setFollowRedirects(true);
 	      HttpURLConnection con = (HttpURLConnection) new URL(URLName).openConnection();
 	      // fake request coming from browser
-	      con.setRequestProperty("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36");
+	      con.setRequestProperty("User-Agent", "Mozilla/5.0 SPDX LicenseListPublisher (File issues on the https://github.com/spdx/LicenseListPublisher/ issue tracker.)");
 	      con.setRequestMethod("HEAD");
 	      con.setConnectTimeout(30000);
 		  con.setReadTimeout(30000);
@@ -63,7 +63,7 @@ public class Live implements Callable<Boolean>  {
 	        return false;
 	    }
 	  }
-	
+
 	@Override
 	public Boolean call() throws Exception {
 		return urlLinkExists(url);


### PR DESCRIPTION
This should fix https://github.com/spdx/LicenseListPublisher/issues/220 at least from the sites that I admin. Instead of tricking the server into thinking LicenseListPublisher is a browser, this would clearly identify the tool and lead to this issue tracker if admins run into a problem.

Reasoning: imperva recommends blocking all Chrome user-agents more than 3 years old on [page 34 of their 2025 Bad Bot Report](https://www.imperva.com/resources/wp-content/uploads/sites/6/reports/2025-Bad-Bot-Report.pdf) and based on the data I am seeing that is sound advice. AI startups with botnets running broken vibe-coded crawlers use Chrome user-agents with randomized version numbers. This tool would either need to continually update the version number every 2-3 years or change strategy like this pull request suggests continue scraping.